### PR TITLE
fix: copy mirror frame styling

### DIFF
--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -6,7 +6,7 @@ import "./styles.css";
 
 export default function App(): JSX.Element {
     const [usingPortal, setUsingPortal] = React.useState(false);
-    const [ref, reflection] = useMirror();
+    const [ref, reflection] = useMirror({ className: "Frame" });
     return (
         <div className="App">
             <h1>React Mirror Demo</h1>

--- a/demo/src/styles.css
+++ b/demo/src/styles.css
@@ -1,4 +1,4 @@
-.App {
+.App, .Frame {
   font-family: sans-serif;
   text-align: center;
 }

--- a/src/clone.ts
+++ b/src/clone.ts
@@ -10,7 +10,10 @@ function randomString(length: number): string {
     return str;
 }
 
-function copyStyles(sourceElt: HTMLElement, targetElt: HTMLElement): void {
+export function copyStyles(
+    sourceElt: HTMLElement,
+    targetElt: HTMLElement,
+): void {
     const styleDecls: { [key: string]: CSSStyleDeclaration } = {};
     const pseudoRegex = /:(:?)[a-z-]+/g;
     for (let i = 0; i < document.styleSheets.length; i++) {
@@ -26,7 +29,8 @@ function copyStyles(sourceElt: HTMLElement, targetElt: HTMLElement): void {
         }
     }
     // ensures only the cloned styles are applied to element
-    targetElt.className = `_${randomString(7)}`;
+    const singleClassName = targetElt.className.replace(" ", "-");
+    targetElt.className = `${singleClassName}_${randomString(7)}`;
     // style element used for transfering pseudo styles
     const styleElt = document.createElement("style");
     styleElt.type = "text/css";

--- a/src/clone.ts
+++ b/src/clone.ts
@@ -21,10 +21,18 @@ export function copyStyles(
         const rules = styleSheet.rules || styleSheet.cssRules;
         for (let j = 0; j < rules.length; j++) {
             const rule = rules[j] as CSSStyleRule;
-            // also match pseudo selectors
-            const selector = rule.selectorText?.replace(pseudoRegex, "");
-            if (sourceElt?.matches(selector)) {
-                styleDecls[rule.selectorText] = rule.style;
+            // test each selector in a group separately
+            // accounts for bug with specificity library where
+            // `.classA, .classB` fails when compared with `.classB`
+            // https://github.com/keeganstreet/specificity/issues/4
+            for (const selectorText of rule.selectorText
+                .split(",")
+                .map(s => s.trim())) {
+                // also match pseudo selectors
+                const selector = selectorText?.replace(pseudoRegex, "");
+                if (sourceElt?.matches(selector)) {
+                    styleDecls[selectorText] = rule.style;
+                }
             }
         }
     }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 
-import { deepCloneWithStyles } from "./clone";
+import { deepCloneWithStyles, copyStyles } from "./clone";
 
 type MirrorPropsType = {
     className?: string;
@@ -25,6 +25,10 @@ export function Mirror({ className, reflect }: MirrorPropsType): JSX.Element {
         } else {
             frame.appendChild(reflection);
         }
+        while (frame.firstChild !== frame.lastChild) {
+            frame.removeChild(frame.lastChild);
+        }
+        copyStyles(frame, frame);
     }, [frame, real]);
     // start of the reflection
     React.useEffect(update, [update]);

--- a/tests/__snapshots__/index.test.tsx.snap
+++ b/tests/__snapshots__/index.test.tsx.snap
@@ -57,6 +57,12 @@ exports[`Component renders reflection with styles 1`] = `
           Mock text node
         </p>
       </div>
+      <style
+        type="text/css"
+      >
+        .mirrorFrame_4fzzzxj::before { content: 'mock text'; position: absolute; }
+
+      </style>
     </div>
   </div>
 </body>

--- a/tests/__snapshots__/index.test.tsx.snap
+++ b/tests/__snapshots__/index.test.tsx.snap
@@ -14,14 +14,14 @@ exports[`Component renders reflection with styles 1`] = `
 <body>
   <div>
     <div
-      class="classOne"
+      class="class1 one"
     >
       <span
-        class="classTwo"
+        class="class2 two"
       />
     </div>
     <p
-      class="classThree"
+      class="class3 three"
     >
       Mock text node
     </p>
@@ -36,22 +36,22 @@ exports[`Component renders reflection with styles 1`] = `
         style="pointer-events: none;"
       >
         <div
-          class="classOne_4fzzzxj"
+          class="class1-one_4fzzzxj"
           style="height: 10px; pointer-events: none;"
         >
           <span
-            class="classTwo_4fzzzxj"
+            class="class2-two_4fzzzxj"
             style="font-size: 1.3em; display: block; width: 20px; margin: 0px auto; pointer-events: none;"
           />
         </div>
         <p
-          class="classThree_4fzzzxj"
+          class="class3-three_4fzzzxj"
           style="pointer-events: none;"
         >
           <style
             type="text/css"
           >
-            .classThree_4fzzzxj::after { content: ''; background: red; width: 5px; height: 5px; }
+            .class3-three_4fzzzxj::after { content: ''; background: red; width: 5px; height: 5px; }
 
           </style>
           Mock text node

--- a/tests/__snapshots__/index.test.tsx.snap
+++ b/tests/__snapshots__/index.test.tsx.snap
@@ -27,28 +27,31 @@ exports[`Component renders reflection with styles 1`] = `
     </p>
   </div>
   <div>
-    <div>
+    <div
+      class="mirrorFrame_4fzzzxj"
+      style="font-family: \\"san-serif\\"; font-size: 1.2em;"
+    >
       <div
         class="_4fzzzxj"
         style="pointer-events: none;"
       >
         <div
-          class="_4fzzzxj"
+          class="classOne_4fzzzxj"
           style="height: 10px; pointer-events: none;"
         >
           <span
-            class="_4fzzzxj"
+            class="classTwo_4fzzzxj"
             style="font-size: 1.3em; display: block; width: 20px; margin: 0px auto; pointer-events: none;"
           />
         </div>
         <p
-          class="_4fzzzxj"
+          class="classThree_4fzzzxj"
           style="pointer-events: none;"
         >
           <style
             type="text/css"
           >
-            ._4fzzzxj::after { content: ''; background: red; width: 5px; height: 5px; }
+            .classThree_4fzzzxj::after { content: ''; background: red; width: 5px; height: 5px; }
 
           </style>
           Mock text node

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -44,6 +44,10 @@ describe("Component", (): void => {
                 font-family: "san-serif";
                 font-size: 1.2em;
             }
+            .mirrorFrame::before {
+                content: 'mock text';
+                position: absolute;
+            }
             .classOne {
                 height: 10px;
             }

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -40,7 +40,7 @@ describe("Component", (): void => {
         const domStyle = document.createElement("style");
         document.head.appendChild(domStyle);
         domStyle.innerHTML = `
-            body {
+            body, .mirrorFrame {
                 font-family: "san-serif";
                 font-size: 1.2em;
             }
@@ -75,7 +75,8 @@ describe("Component", (): void => {
         /** render mirror into detached node */
         const spyReplace = jest.spyOn(HTMLElement.prototype, "replaceChild");
         const baseElement = document.createElement("div");
-        render(<Mirror reflect={domNode} />, { baseElement });
+        const renderProps = { className: "mirrorFrame", reflect: domNode };
+        render(<Mirror {...renderProps} />, { baseElement });
         /** add more nodes and check that they are inserted */
         expect(spyReplace).toHaveBeenCalledTimes(0);
         const node3 = document.createElement("p");
@@ -85,7 +86,7 @@ describe("Component", (): void => {
         await new Promise(resolve => setTimeout(resolve));
         expect(spyReplace).toHaveBeenCalledTimes(1);
         /** mirror nodes and check results */
-        const result = render(<Mirror reflect={domNode} />);
+        const result = render(<Mirror {...renderProps} />);
         expect(result.baseElement).toMatchSnapshot();
         /** clean up */
         domStyle.remove();

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -48,22 +48,22 @@ describe("Component", (): void => {
                 content: 'mock text';
                 position: absolute;
             }
-            .classOne {
+            .class1.one, .class2.two {
                 height: 10px;
             }
-            .classTwo {
+            .class2.two {
                 font-size: 1.3em;
                 display: block;
                 width: 40px;
                 margin: 0 auto;
             }
-            .classThree::after {
+            .class3.three::after {
                 content: '';
                 background: red;
                 width: 5px;
                 height: 5px;
             }
-            .classOne .classTwo {
+            .class1.one .class2.two {
                 width: 20px;
             }
         `;
@@ -72,10 +72,10 @@ describe("Component", (): void => {
         document.body.appendChild(domNode);
         const node1 = document.createElement("div");
         domNode.appendChild(node1);
-        node1.className = "classOne";
+        node1.className = "class1 one";
         const node2 = document.createElement("span");
         node1.appendChild(node2);
-        node2.className = "classTwo";
+        node2.className = "class2 two";
         /** render mirror into detached node */
         const spyReplace = jest.spyOn(HTMLElement.prototype, "replaceChild");
         const baseElement = document.createElement("div");
@@ -86,7 +86,7 @@ describe("Component", (): void => {
         const node3 = document.createElement("p");
         domNode.appendChild(node3);
         node3.innerHTML = "Mock text node";
-        node3.className = "classThree";
+        node3.className = "class3 three";
         await new Promise(resolve => setTimeout(resolve));
         expect(spyReplace).toHaveBeenCalledTimes(1);
         /** mirror nodes and check results */


### PR DESCRIPTION
# Description

Copy mirror frame styling to inline

## Changes

- Inline frame styles
- Make decoupled class names easier to recognise

### Checklist

- [x] This PR has updated documentation
- [x] This PR has sufficient testing

### Comments

- Addition comments for reviewers
