### PR TITLE
fix: all cloned items should share class instance id

### DIFF
--- a/src/clone.ts
+++ b/src/clone.ts
@@ -35,9 +35,7 @@ export function copyStyles(
     }
     // ensures only the cloned styles are applied to element
     const singleClassName = targetElt.className.replace(" ", "-");
-    targetElt.className = `${singleClassName}${
-        options?.class ? `_${options.class}` : ""
-    }`;
+    targetElt.className = `${singleClassName}${options?.class || ""}`;
     // style element used for transfering pseudo styles
     const styleElt = document.createElement("style");
     styleElt.type = "text/css";

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -21,7 +21,7 @@ export function Mirror({ className, reflect }: MirrorPropsType): JSX.Element {
     const update = React.useCallback(() => {
         if (!frame || !real) return;
         const cloneOptions: CloneOptions = {
-            class: instanceId,
+            class: `_${instanceId}`,
             styles: { pointerEvents: "none" },
         };
         const reflection = deepCloneWithStyles(real as Element, cloneOptions);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,13 @@
+export function randomString(length: number): string {
+    let str = "";
+    while (str.length < length) {
+        str += Math.random()
+            .toString(36)
+            .substr(2, length - str.length);
+    }
+    return str;
+}
+
+export function camelToSpinalCase(camelCase: string): string {
+    return camelCase.replace(/([A-Z])/g, "-$1").toLocaleLowerCase();
+}


### PR DESCRIPTION
# Description

Easier to apply styles if the cloned items don't all have random ids

## Changes

- All cloned items in the tree suffixed with the same instance id

### Checklist

- [ ] This PR has updated documentation
- [x] This PR has sufficient testing

### Comments

N/A