### PR TITLE
fix: do not break when only pseudo element selectors are used

### DIFF
--- a/demo/src/Clock.tsx
+++ b/demo/src/Clock.tsx
@@ -17,7 +17,7 @@ export function Clock(): JSX.Element {
         Hour: (date.getHours() % 12) / 12,
     };
     return (
-        <div className="Clock Face">
+        <div className="Clock Face" data-name="MyClock">
             {Object.entries(ratios).map(([cls, ratio]) => (
                 <span
                     key={cls}

--- a/demo/src/styles.css
+++ b/demo/src/styles.css
@@ -11,6 +11,10 @@
   border-radius: 4px;
 }
 
+.Input:hover {
+  border-color: dodgerblue;
+}
+
 .Button {
   cursor: pointer;
   margin: 0 auto;
@@ -32,7 +36,7 @@
   border-radius: 100%;
 }
 
-.Clock.Face::after {
+.Clock[data-name="MyClock"]::after {
   content: '';
   position: absolute;
   background-color: black;

--- a/src/clone.ts
+++ b/src/clone.ts
@@ -27,8 +27,8 @@ export function copyStyles(
                 .map((s) => s.trim())
                 .filter(Boolean)) {
                 const selector = selectorText.replace(pseudoElementRegex, "");
-                // if selector is empty then selectorText was all pseudo element
-                // selector which means that it should be applied to all elements
+                // if {selector} is empty then {selectorText} was only pseudo element
+                // selectors which means it should be applied to all elements i.e. *
                 if (sourceElt?.matches(selector || "*")) {
                     styleDecls[selectorText] = rule.style;
                 }

--- a/src/clone.ts
+++ b/src/clone.ts
@@ -1,5 +1,9 @@
 import { compare } from "specificity";
-import { camelToSpinalCase } from "./utils";
+import {
+    camelToSpinalCase,
+    getPseudoElementSelector,
+    splitSelectors,
+} from "./utils";
 
 export type CloneOptions = {
     styles?: React.CSSProperties;
@@ -12,7 +16,6 @@ export function copyStyles(
     options?: CloneOptions,
 ): void {
     const styleDecls: { [key: string]: CSSStyleDeclaration } = {};
-    const pseudoElementRegex = /::[a-z-]+/g;
     for (let i = 0; i < document.styleSheets.length; i++) {
         const styleSheet = document.styleSheets[i] as CSSStyleSheet;
         const rules = styleSheet.rules || styleSheet.cssRules;
@@ -22,15 +25,20 @@ export function copyStyles(
             // accounts for bug with specificity library where
             // `.classA, .classB` fails when compared with `.classB`
             // https://github.com/keeganstreet/specificity/issues/4
-            for (const selectorText of rule.selectorText
-                .split(",")
-                .map((s) => s.trim())
-                .filter(Boolean)) {
-                const selector = selectorText.replace(pseudoElementRegex, "");
-                // if {selector} is empty then {selectorText} was only pseudo element
-                // selectors which means it should be applied to all elements i.e. *
-                if (sourceElt?.matches(selector || "*")) {
-                    styleDecls[selectorText] = rule.style;
+            for (const selectorText of splitSelectors(rule.selectorText)) {
+                const selector = selectorText.replace(
+                    getPseudoElementSelector(selectorText),
+                    "",
+                );
+                // If selector has a pseudo element pattern then just include it since
+                // Pseudo elements match the parent and safely extracting it is complicated
+                try {
+                    if (sourceElt?.matches(selector || "*")) {
+                        styleDecls[selectorText] = rule.style;
+                    }
+                } catch (e) {
+                    // eslint-disable-next-line no-console
+                    console.error(e.message, { selectorText });
                 }
             }
         }
@@ -43,12 +51,10 @@ export function copyStyles(
     styleElt.type = "text/css";
     for (const selector of Object.keys(styleDecls).sort(compare)) {
         const styleDecl = styleDecls[selector];
-        const pseudos = selector.match(pseudoElementRegex);
         // store pseudo element styles in style element
-        if (pseudos?.length) {
-            for (const p of new Set(pseudos)) {
-                styleElt.innerHTML += `.${targetElt.className}${p} { ${styleDecl.cssText} }\n`;
-            }
+        const pseudoElementSelector = getPseudoElementSelector(selector);
+        if (pseudoElementSelector) {
+            styleElt.innerHTML += `.${targetElt.className}${pseudoElementSelector} { ${styleDecl.cssText} }\n`;
         } else {
             for (let i = 0; i < styleDecl.length; i++) {
                 const propName = styleDecl[i];

--- a/src/clone.ts
+++ b/src/clone.ts
@@ -26,12 +26,11 @@ export function copyStyles(
             // `.classA, .classB` fails when compared with `.classB`
             // https://github.com/keeganstreet/specificity/issues/4
             for (const selectorText of splitSelectors(rule.selectorText)) {
+                // also match pseudo selectors
                 const selector = selectorText.replace(
                     getPseudoElementSelector(selectorText),
                     "",
                 );
-                // If selector has a pseudo element pattern then just include it since
-                // Pseudo elements match the parent and safely extracting it is complicated
                 try {
                     if (sourceElt?.matches(selector || "*")) {
                         styleDecls[selectorText] = rule.style;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -39,9 +39,9 @@ export function Mirror({ className, reflect }: MirrorPropsType): JSX.Element {
     // start of the reflection
     React.useEffect(update, [update]);
     // mutation observer single instance
-    const observer = React.useMemo(() => new MutationObserver(update), [
-        update,
-    ]);
+    const observer = React.useMemo(() => {
+        return new MutationObserver(update);
+    }, [update]);
     // observe or disconnect when real node is set or unmounted
     React.useEffect(() => {
         if (!real || !observer) return undefined;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,3 +11,51 @@ export function randomString(length: number): string {
 export function camelToSpinalCase(camelCase: string): string {
     return camelCase.replace(/([A-Z])/g, "-$1").toLocaleLowerCase();
 }
+
+export function splitSelectors(selectors: string): string[] {
+    if (!selectors) {
+        return [];
+    }
+    if (isAtRule(selectors)) {
+        return [selectors];
+    }
+    const splitted = [];
+    let quotes = 0;
+    let parens = 0;
+    let angulars = 0;
+    let soFar = "";
+    for (let i = 0, len = selectors.length; i < len; i++) {
+        const char = selectors[i];
+        if (char === "(") {
+            parens += 1;
+        } else if (char === ")") {
+            parens -= 1;
+        } else if (char === "[") {
+            angulars += 1;
+        } else if (char === "]") {
+            angulars -= 1;
+        } else if (char === '"') {
+            quotes += 1;
+        } else if (char === ",") {
+            if (!parens && !angulars && !(quotes % 2)) {
+                splitted.push(soFar.trim());
+                soFar = "";
+                continue;
+            }
+        }
+        soFar += char;
+    }
+    splitted.push(soFar.trim());
+    return splitted.filter(Boolean);
+}
+
+function isAtRule(selector: string): boolean {
+    return selector.indexOf("@") === 0;
+}
+
+export function getPseudoElementSelector(selector: string): string {
+    const pseudoElementSelector = /::\w+(\(\w+\))?/g;
+    return pseudoElementSelector.test(selector)
+        ? selector.match(pseudoElementSelector)[0]
+        : "";
+}

--- a/tests/__snapshots__/index.test.tsx.snap
+++ b/tests/__snapshots__/index.test.tsx.snap
@@ -35,14 +35,33 @@ exports[`Component renders reflection with styles 1`] = `
         class="_4fzzzxj"
         style="pointer-events: none;"
       >
+        <style
+          type="text/css"
+        >
+          ._4fzzzxj::after { content: ''; position: absolute; }
+
+        </style>
         <div
           class="class1-one_4fzzzxj"
           style="height: 10px; pointer-events: none;"
         >
+          <style
+            type="text/css"
+          >
+            .class1-one_4fzzzxj::after { content: ''; position: absolute; }
+
+          </style>
           <span
             class="class2-two_4fzzzxj"
             style="font-size: 1.3em; display: block; width: 20px; margin: 0px auto; pointer-events: none;"
-          />
+          >
+            <style
+              type="text/css"
+            >
+              .class2-two_4fzzzxj::after { content: ''; position: absolute; }
+
+            </style>
+          </span>
         </div>
         <p
           class="class3-three_4fzzzxj"
@@ -51,7 +70,8 @@ exports[`Component renders reflection with styles 1`] = `
           <style
             type="text/css"
           >
-            .class3-three_4fzzzxj::after { content: ''; background: red; width: 5px; height: 5px; }
+            .class3-three_4fzzzxj::after { content: ''; position: absolute; }
+.class3-three_4fzzzxj::after { content: ''; background: red; width: 5px; height: 5px; }
 
           </style>
           Mock text node
@@ -60,7 +80,8 @@ exports[`Component renders reflection with styles 1`] = `
       <style
         type="text/css"
       >
-        .mirrorFrame_4fzzzxj::before { content: 'mock text'; position: absolute; }
+        .mirrorFrame_4fzzzxj::after { content: ''; position: absolute; }
+.mirrorFrame_4fzzzxj::before { content: 'mock text'; position: absolute; }
 
       </style>
     </div>

--- a/tests/__snapshots__/index.test.tsx.snap
+++ b/tests/__snapshots__/index.test.tsx.snap
@@ -14,6 +14,7 @@ exports[`Component renders reflection with styles 1`] = `
 <body>
   <div>
     <div
+      attr="[value"
       class="class1 one"
     >
       <span
@@ -29,7 +30,6 @@ exports[`Component renders reflection with styles 1`] = `
   <div>
     <div
       class="mirrorFrame_4fzzzxj"
-      style="font-family: \\"san-serif\\"; font-size: 1.2em;"
     >
       <div
         class="_4fzzzxj"
@@ -38,17 +38,20 @@ exports[`Component renders reflection with styles 1`] = `
         <style
           type="text/css"
         >
-          ._4fzzzxj::after { content: ''; position: absolute; }
+          ._4fzzzxj::before { position: absolute; }
+._4fzzzxj::after { content: ''; }
 
         </style>
         <div
+          attr="[value"
           class="class1-one_4fzzzxj"
           style="height: 10px; pointer-events: none;"
         >
           <style
             type="text/css"
           >
-            .class1-one_4fzzzxj::after { content: ''; position: absolute; }
+            .class1-one_4fzzzxj::before { position: absolute; }
+.class1-one_4fzzzxj::after { content: ''; }
 
           </style>
           <span
@@ -58,7 +61,8 @@ exports[`Component renders reflection with styles 1`] = `
             <style
               type="text/css"
             >
-              .class2-two_4fzzzxj::after { content: ''; position: absolute; }
+              .class2-two_4fzzzxj::before { position: absolute; }
+.class2-two_4fzzzxj::after { content: ''; }
 
             </style>
           </span>
@@ -70,8 +74,9 @@ exports[`Component renders reflection with styles 1`] = `
           <style
             type="text/css"
           >
-            .class3-three_4fzzzxj::after { content: ''; position: absolute; }
-.class3-three_4fzzzxj::after { content: ''; background: red; width: 5px; height: 5px; }
+            .class3-three_4fzzzxj::before { position: absolute; }
+.class3-three_4fzzzxj::after { content: ''; }
+.class3-three_4fzzzxj::after { background: red; width: 5px; height: 5px; }
 
           </style>
           Mock text node
@@ -80,8 +85,9 @@ exports[`Component renders reflection with styles 1`] = `
       <style
         type="text/css"
       >
-        .mirrorFrame_4fzzzxj::after { content: ''; position: absolute; }
-.mirrorFrame_4fzzzxj::before { content: 'mock text'; position: absolute; }
+        .mirrorFrame_4fzzzxj::before { position: absolute; }
+.mirrorFrame_4fzzzxj::after { content: ''; }
+.mirrorFrame_4fzzzxj::before { content: 'mock text'; }
 
       </style>
     </div>

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -48,6 +48,10 @@ describe("Component", (): void => {
         const domStyle = document.createElement("style");
         document.head.appendChild(domStyle);
         domStyle.innerHTML = `
+            ::after {
+                content: '';
+                position: absolute;
+            }
             body, .mirrorFrame {
                 font-family: "san-serif";
                 font-size: 1.2em;

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -48,17 +48,25 @@ describe("Component", (): void => {
         const domStyle = document.createElement("style");
         document.head.appendChild(domStyle);
         domStyle.innerHTML = `
-            ::after {
-                content: '';
-                position: absolute;
+            @charset "utf-8";
+            @font-face {
+                font-family: "Open Sans";
             }
-            body, .mirrorFrame {
+            body, .mirrorFrame:not(*) {
                 font-family: "san-serif";
                 font-size: 1.2em;
             }
+            :is(::after), ::before {
+                position: absolute;
+            }
+            :where(::slotted(span)) {
+                border: none;
+            }
+            ::after {
+                content: '';
+            }
             .mirrorFrame::before {
                 content: 'mock text';
-                position: absolute;
             }
             .class1.one, .class2.two {
                 height: 10px;
@@ -70,12 +78,11 @@ describe("Component", (): void => {
                 margin: 0 auto;
             }
             .class3.three::after {
-                content: '';
                 background: red;
                 width: 5px;
                 height: 5px;
             }
-            .class1.one .class2.two {
+            .class1.one[attr^="[val"] .class2.two {
                 width: 20px;
             }
         `;
@@ -85,6 +92,7 @@ describe("Component", (): void => {
         const node1 = document.createElement("div");
         domNode.appendChild(node1);
         node1.className = "class1 one";
+        node1.setAttribute("attr", "[value");
         const node2 = document.createElement("span");
         node1.appendChild(node2);
         node2.className = "class2 two";


### PR DESCRIPTION
# Description

Fixes #778

## Changes

- Fix: selector group splitting
- Fix: pseudo selector cloning 
- Updated test cases to catch edges

### Checklist

- [x] This PR has updated documentation
- [x] This PR has sufficient testing

### Comments

N/A
